### PR TITLE
smol bug on y2015-d5

### DIFF
--- a/2015/src/bin/day_05.rs
+++ b/2015/src/bin/day_05.rs
@@ -19,7 +19,7 @@ fn is_nice_string_1(input: &str) -> bool {
         .count()
         >= 3
         && input.chars().tuple_windows().any(|(a, b)| a == b)
-        && ["ab", "cb", "pq", "xy"].iter().all(|&s| !input.contains(s))
+        && ["ab", "cd", "pq", "xy"].iter().all(|&s| !input.contains(s))
 }
 
 fn is_nice_string_2(input: &str) -> bool {


### PR DESCRIPTION
The banned string are `ab, cd, pq, xy`:

> It does not contain the strings ab, cd, pq, or xy, even if they are part of one of the other requirements.

https://adventofcode.com/2015/day/5